### PR TITLE
Deixando mensagem de erro mais clara, e criando erro específico para 429

### DIFF
--- a/src/Controllers/BaseController.php
+++ b/src/Controllers/BaseController.php
@@ -88,11 +88,14 @@ class BaseController
         if ($response->getStatusCode() == 422) {
             throw new Exceptions\ErrorException('Contract validation error', $_httpContext);
         }
+        if ($response->getStatusCode() == 429) {
+            throw new Exceptions\ErrorException('API Rate Limit Exceeded', $_httpContext);
+        }
         if ($response->getStatusCode() == 500) {
             throw new Exceptions\ErrorException('Internal server error', $_httpContext);
         }
         if (($response->getStatusCode() < 200) || ($response->getStatusCode() > 208)) { //[200,208] = HTTP OK
-            throw new APIException('HTTP Response Not OK', $_httpContext);
+            throw new APIException('An Error Has Occurred. Status returned was: ' . $response->getStatusCode(), $_httpContext);
         }
     }
 }


### PR DESCRIPTION
- Deixando a mensagem de erro padrão mais clara para que não seja necessario debugar dentro da biblioteca quando um erro não tratado anteriormente acontecere, mostrando o status do response.
- Criando um exception expecifico para o 429 para que quando exceder o rate limit da api, mostrar uma mensagem clara sobre o que aconteceu CLI-21023